### PR TITLE
feat: complete deployment guide — VPS + Docker Compose path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,15 @@
 # Database
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/hq
+# For Docker: use "postgres" as host (the service name)
+DATABASE_URL=postgresql://hq:changeme@postgres:5432/hq_prod
+POSTGRES_PASSWORD=changeme
 
-# Internal app communication secret (generate a random string)
+# Security (generate with: openssl rand -hex 32)
 INTERNAL_APP_SHARED_SECRET=change-me
-
-# Session signing secret (minimum 32 characters)
 SESSION_SECRET=change-me-at-least-32-characters-long
 
-# Superadmin emails (comma-separated)
+# Access
 SUPERADMIN_EMAIL_ALLOWLIST=admin@example.com
 
-# AI model API keys (add the ones you need)
+# AI (add the keys you need)
 ANTHROPIC_API_KEY=
 OPENAI_API_KEY=

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,109 @@
+# Deploying HQ
+
+HQ runs as three Docker containers: API, Workshop (UI), and Postgres.
+One server, one compose file, 20 minutes.
+
+## Prerequisites
+
+- A VPS with Ubuntu 22.04+ (DigitalOcean, Hetzner, Vultr, etc.) — 2GB RAM minimum
+- A domain name pointed at your server (A record)
+- SSH access to root or sudo user
+
+## Step 1 — Prepare the server
+
+SSH in and run the setup script:
+
+```bash
+ssh root@your-server-ip
+curl -fsSL https://raw.githubusercontent.com/aiwah-labs/hq/main/scripts/setup-server.sh | bash
+```
+
+This installs Docker, Docker Compose, and nginx with Certbot.
+
+## Step 2 — Clone and configure
+
+```bash
+git clone https://github.com/aiwah-labs/hq /opt/hq
+cd /opt/hq
+cp .env.example .env.prod
+```
+
+Edit `.env.prod` with your values:
+
+```bash
+nano .env.prod
+```
+
+Required variables:
+
+| Variable | Value |
+|---|---|
+| DATABASE_URL | `postgresql://hq:your-db-password@postgres:5432/hq_prod` |
+| INTERNAL_APP_SHARED_SECRET | run: `openssl rand -hex 32` |
+| SESSION_SECRET | run: `openssl rand -hex 32` |
+| SUPERADMIN_EMAIL_ALLOWLIST | your@email.com |
+| ANTHROPIC_API_KEY | your Anthropic API key |
+
+## Step 3 — Deploy
+
+```bash
+cd /opt/hq
+bash scripts/first-deploy.sh
+```
+
+This builds images, runs migrations, seeds the database, and starts all containers.
+
+## Step 4 — Set up SSL and nginx
+
+```bash
+bash scripts/setup-nginx.sh your-domain.com
+```
+
+This configures nginx as a reverse proxy and issues a Let's Encrypt certificate.
+
+Your Workshop is now live at `https://your-domain.com`.
+
+## Updating
+
+When a new version is available:
+
+```bash
+cd /opt/hq && bash scripts/deploy-prod.sh
+```
+
+## Health check
+
+```bash
+curl https://your-domain.com/api/v1/health
+# {"status":"ok"}
+```
+
+## Logs
+
+```bash
+# All containers
+docker compose -f docker-compose.prod.yml logs -f
+
+# API only
+bash scripts/logs.sh api tail
+
+# Errors only
+bash scripts/logs.sh api errors
+```
+
+## Troubleshooting
+
+**Containers not starting**
+
+```bash
+docker compose -f docker-compose.prod.yml ps
+docker compose -f docker-compose.prod.yml logs api
+```
+
+**Database connection error**
+
+Check that `DATABASE_URL` in `.env.prod` uses `postgres` as the host (the Docker service name), not `localhost`.
+
+**Port already in use**
+
+Check what's using the port: `lsof -i :3002`

--- a/README.md
+++ b/README.md
@@ -12,15 +12,31 @@ git clone https://github.com/aiwah-labs/hq
 
 ## Getting started
 
-Clone the repo and point a coding agent at it — Claude Code, Cursor, Codex, or any agent that can read and write code. Tell it what your business does and what you need. The platform is designed to be extended through conversation.
+### Local development
+
+Prerequisites: Node.js 22+, pnpm 10+, Docker (for Postgres)
 
 ```bash
 git clone https://github.com/aiwah-labs/hq
 cd hq
-pnpm install
-cp .env.example .env
-pnpm db:local:bootstrap
-pnpm dev:platform
+make setup
+make dev
+```
+
+Workshop runs at http://localhost:3002 · API at http://localhost:3003
+
+### Production deployment
+
+See [DEPLOY.md](./DEPLOY.md) for the full guide. The short version:
+
+```bash
+# On a fresh Ubuntu VPS
+curl -fsSL https://raw.githubusercontent.com/aiwah-labs/hq/main/scripts/setup-server.sh | bash
+git clone https://github.com/aiwah-labs/hq /opt/hq
+cd /opt/hq && cp .env.example .env.prod
+# edit .env.prod
+bash scripts/first-deploy.sh
+bash scripts/setup-nginx.sh your-domain.com
 ```
 
 ---

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,34 +2,40 @@ services:
   postgres:
     image: postgres:16
     environment:
-      POSTGRES_DB: hq
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: hq_prod
+      POSTGRES_USER: hq
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
       - postgres_data:/var/lib/postgresql/data
-    restart: always
+    restart: unless-stopped
 
   api:
     build:
       context: .
       dockerfile: apps/api/Dockerfile
-    env_file: .env
+    env_file: .env.prod
     ports:
       - "3003:3003"
     depends_on:
       - postgres
-    restart: always
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3003/api/v1/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
 
   workshop:
     build:
       context: .
       dockerfile: apps/workshop/Dockerfile
-    env_file: .env
+    env_file: .env.prod
     ports:
       - "3002:3002"
     depends_on:
       - api
-    restart: always
+    restart: unless-stopped
 
 volumes:
   postgres_data:

--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -1,19 +1,18 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
-echo "Deploying production..."
-cd /opt/aiwah-hq
+cd "$(dirname "$0")/.."
 
-echo "Fetching latest changes..."
-git fetch origin
+echo "Pulling latest changes..."
+git pull origin main
 
-echo "Resetting to production branch..."
-git reset --hard origin/production
-
-echo "Building images..."
+echo "Building updated images..."
 docker compose -f docker-compose.prod.yml --env-file .env.prod build
 
-echo "Starting containers..."
+echo "Running migrations..."
+docker compose -f docker-compose.prod.yml --env-file .env.prod run --rm api pnpm db:migrate:prod
+
+echo "Restarting services..."
 docker compose -f docker-compose.prod.yml --env-file .env.prod up -d
 
 echo "Deployment complete!"

--- a/scripts/first-deploy.sh
+++ b/scripts/first-deploy.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+echo "[1/4] Building images..."
+docker compose -f docker-compose.prod.yml --env-file .env.prod build
+
+echo "[2/4] Starting postgres..."
+docker compose -f docker-compose.prod.yml --env-file .env.prod up -d postgres
+sleep 5
+
+echo "[3/4] Running migrations and seed..."
+docker compose -f docker-compose.prod.yml --env-file .env.prod run --rm api sh -c "pnpm db:migrate:prod && pnpm db:seed"
+
+echo "[4/4] Starting all services..."
+docker compose -f docker-compose.prod.yml --env-file .env.prod up -d
+
+echo ""
+echo "HQ is running!"
+echo "API:      http://localhost:3003"
+echo "Workshop: http://localhost:3002"
+echo ""
+echo "Next: bash scripts/setup-nginx.sh your-domain.com"

--- a/scripts/setup-nginx.sh
+++ b/scripts/setup-nginx.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOMAIN="${1:-}"
+if [ -z "$DOMAIN" ]; then
+  echo "Usage: $0 your-domain.com"
+  exit 1
+fi
+
+# Write nginx config
+cat > /etc/nginx/sites-available/hq << EOF
+server {
+    listen 80;
+    server_name $DOMAIN;
+
+    location / {
+        proxy_pass http://localhost:3002;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host \$host;
+        proxy_cache_bypass \$http_upgrade;
+    }
+
+    location /api {
+        proxy_pass http://localhost:3003;
+        proxy_http_version 1.1;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+    }
+}
+EOF
+
+ln -sf /etc/nginx/sites-available/hq /etc/nginx/sites-enabled/hq
+nginx -t
+systemctl reload nginx
+
+echo "Issuing SSL certificate for $DOMAIN..."
+certbot --nginx -d "$DOMAIN" --non-interactive --agree-tos -m "admin@$DOMAIN" --redirect
+
+echo ""
+echo "Done! HQ is live at https://$DOMAIN"

--- a/scripts/setup-server.sh
+++ b/scripts/setup-server.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[1/4] Installing Docker..."
+apt-get update -qq
+apt-get install -y ca-certificates curl gnupg
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+chmod a+r /etc/apt/keyrings/docker.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+apt-get update -qq
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+echo "[2/4] Installing nginx + certbot..."
+apt-get install -y nginx certbot python3-certbot-nginx
+
+echo "[3/4] Configuring firewall..."
+ufw allow OpenSSH
+ufw allow 'Nginx Full'
+ufw --force enable
+
+echo "[4/4] Done."
+echo ""
+echo "Next: git clone https://github.com/aiwah-labs/hq /opt/hq && cd /opt/hq && cp .env.example .env.prod"


### PR DESCRIPTION
## What this does

Makes the VPS + Docker Compose deployment path bulletproof for developers cloning the repo.

## Changes

- **`DEPLOY.md`** — definitive zero-to-live deployment guide
- **`scripts/setup-server.sh`** — one-shot Ubuntu VPS setup: Docker, nginx, certbot, UFW firewall
- **`scripts/first-deploy.sh`** — first-time deploy: build images, run migrations+seed, start all containers
- **`scripts/setup-nginx.sh`** — nginx reverse proxy config + Let's Encrypt SSL via certbot
- **`scripts/deploy-prod.sh`** — cleaner update flow (pull → build → migrate → restart)
- **`docker-compose.prod.yml`** — `restart: unless-stopped` on all services, healthcheck on API, `POSTGRES_PASSWORD` from env instead of hardcoded
- **`README.md`** — cleaner getting-started section covering both local dev and prod paths; removes Codespaces badge
- **`.env.example`** — adds `POSTGRES_PASSWORD`, clarifies Docker hostname in `DATABASE_URL`