### PR TITLE
feat(workshop): adopt Linear/Attio tool look design system

### DIFF
--- a/apps/workshop/src/app/(app)/dashboard/page.tsx
+++ b/apps/workshop/src/app/(app)/dashboard/page.tsx
@@ -1,10 +1,82 @@
+import Link from 'next/link';
+
+// Linear/Attio-style operational dashboard. See skills/ui-design/SKILL.md.
+
+const stats = [
+  { label: 'Open approvals', value: '—', sub: 'Awaiting review' },
+  { label: 'Active workflows', value: '—', sub: 'Running now' },
+  { label: 'Inbox unread', value: '—', sub: 'Last 24h' },
+  { label: 'Agents online', value: '—', sub: 'Ready to work' },
+];
+
+const quickLinks: Array<{ href: string; label: string; meta: string }> = [
+  { href: '/inbox', label: 'Inbox', meta: 'Triage messages and requests' },
+  { href: '/approvals', label: 'Approvals', meta: 'Review and sign off' },
+  { href: '/workflows', label: 'Workflows', meta: 'Design and run automations' },
+  { href: '/agents', label: 'Agents', meta: 'Manage AI workers' },
+  { href: '/objects', label: 'Objects', meta: 'CRM records and custom types' },
+  { href: '/files', label: 'Files', meta: 'Documents and shared media' },
+];
+
 export default function DashboardPage() {
   return (
-    <div>
-      <h1 style={{ fontSize: 24, fontWeight: 700, marginBottom: 8 }}>Welcome to HQ</h1>
-      <p style={{ color: '#6b7280' }}>
-        Your organisation's operating system. Use the sidebar to navigate.
-      </p>
+    <div className="mx-auto w-full max-w-[1360px] px-6 pt-6 pb-10">
+      {/* Header */}
+      <div className="mb-6">
+        <div className="mb-2.5 flex items-center gap-2 text-[11px] text-[#8a8f98]">
+          <span className="font-medium">Home</span>
+          <span className="text-[#d0d6e0]">/</span>
+          <span>Dashboard</span>
+        </div>
+        <h1 className="text-[20px] font-semibold leading-none tracking-[-0.01em] text-[#0f1011]">
+          Welcome to HQ
+        </h1>
+        <p className="mt-2 text-[12.5px] text-[#62666d]">
+          Your organisation&rsquo;s operating system. Use the sidebar to navigate, or jump in below.
+        </p>
+      </div>
+
+      {/* Stat row */}
+      <div className="mb-8 flex items-stretch overflow-hidden rounded-lg border border-[#e6e8eb] bg-white">
+        {stats.map((s, i) => (
+          <div
+            key={s.label}
+            className={`flex-1 px-4 py-3 ${i > 0 ? 'border-l border-[#e6e8eb]' : ''}`}
+          >
+            <p className="text-[10.5px] font-medium uppercase tracking-[0.04em] text-[#8a8f98]">
+              {s.label}
+            </p>
+            <p className="mt-1 text-[18px] font-semibold leading-none tabular-nums tracking-tight text-[#0f1011]">
+              {s.value}
+            </p>
+            <p className="mt-1.5 text-[11px] text-[#8a8f98]">{s.sub}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Quick links */}
+      <div className="mb-3 flex items-baseline gap-2">
+        <h2 className="text-[11px] font-semibold uppercase tracking-[0.06em] text-[#0f1011]">
+          Jump in
+        </h2>
+        <p className="text-[11px] text-[#8a8f98]">&mdash; the six things you open most</p>
+      </div>
+
+      <div className="divide-y divide-[#eff0f2] rounded-lg border border-[#e6e8eb] bg-white">
+        {quickLinks.map((l) => (
+          <Link
+            key={l.href}
+            href={l.href}
+            className="group flex h-11 items-center px-4 transition-colors hover:bg-[#fafbfb]"
+          >
+            <span className="text-[12.5px] font-medium text-[#0f1011]">{l.label}</span>
+            <span className="ml-3 text-[11.5px] text-[#8a8f98]">{l.meta}</span>
+            <span className="ml-auto text-[11px] text-[#d0d6e0] transition-colors group-hover:text-[#62666d]">
+              &rsaquo;
+            </span>
+          </Link>
+        ))}
+      </div>
     </div>
   );
 }

--- a/apps/workshop/src/app/globals.css
+++ b/apps/workshop/src/app/globals.css
@@ -24,15 +24,16 @@
 }
 
 :root {
-  --app-bg: #f4f7fb;
+  /* Linear/Attio light — see skills/ui-design/SKILL.md */
+  --app-bg: #fafbfb;
   --app-bg-elevated: #ffffff;
   --app-surface: #ffffff;
-  --app-hover: #eef2f7;
-  --app-fg: #0f172a;
-  --app-muted: #4f5f73;
-  --app-border: #e7edf5;
+  --app-hover: #f7f8f8;
+  --app-fg: #0f1011;
+  --app-muted: #62666d;
+  --app-border: #e6e8eb;
   --app-input-bg: #ffffff;
-  --app-shadow: 0 1px 2px rgba(15, 23, 42, 0.03);
+  --app-shadow: none;
 
   --sidebar-bg: #0f172a;
   --sidebar-fg: #f8fafc;
@@ -64,15 +65,15 @@
 }
 
 html[data-theme='light'] {
-  --app-bg: #f4f7fb;
+  --app-bg: #fafbfb;
   --app-bg-elevated: #ffffff;
   --app-surface: #ffffff;
-  --app-hover: #eef2f7;
-  --app-fg: #0f172a;
-  --app-muted: #4f5f73;
-  --app-border: #e7edf5;
+  --app-hover: #f7f8f8;
+  --app-fg: #0f1011;
+  --app-muted: #62666d;
+  --app-border: #e6e8eb;
   --app-input-bg: #ffffff;
-  --app-shadow: 0 1px 2px rgba(15, 23, 42, 0.03);
+  --app-shadow: none;
 
   --sidebar-bg: #0f172a;
   --sidebar-fg: #f8fafc;
@@ -116,8 +117,9 @@ body {
   margin: 0;
   background: var(--app-bg);
   color: var(--app-fg);
-  font-size: 13px;
+  font-size: 12.5px;
   line-height: 1.45;
+  font-feature-settings: 'cv11', 'ss01';
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -135,7 +137,6 @@ select {
 .card-surface {
   border: 1px solid var(--app-border);
   background: var(--app-bg-elevated);
-  box-shadow: var(--app-shadow);
   overflow: hidden;
   max-width: 100%;
   width: 100%;

--- a/apps/workshop/src/components/ui/badge.tsx
+++ b/apps/workshop/src/components/ui/badge.tsx
@@ -1,27 +1,60 @@
 import type { HTMLAttributes } from 'react';
 import { cn } from '@/lib/cn';
 
+// Badge — Linear/Attio style. Default is a subtle tinted chip. For status,
+// prefer `<StatusDot>` (dot + medium text, no pill) over a filled badge.
+
 interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
-  tone?: 'neutral' | 'success' | 'danger' | 'teal' | 'blue';
+  tone?: 'neutral' | 'success' | 'danger' | 'warn' | 'teal' | 'blue' | 'indigo';
 }
 
 const toneStyles: Record<NonNullable<BadgeProps['tone']>, string> = {
-  neutral: 'border-slate-200 bg-slate-100 text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200',
-  success: 'border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-700/60 dark:bg-emerald-950/40 dark:text-emerald-200',
-  danger: 'border-red-200 bg-red-50 text-red-700 dark:border-red-700/60 dark:bg-red-950/40 dark:text-red-200',
-  teal: 'border-brand-teal/20 bg-brand-teal/10 text-brand-teal-dark dark:border-brand-teal/40 dark:bg-brand-teal/20 dark:text-brand-teal-tint',
-  blue: 'border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-700/60 dark:bg-sky-950/40 dark:text-sky-200',
+  neutral: 'bg-[#f3f4f5] text-[#3d4149]',
+  success: 'bg-emerald-50 text-emerald-700',
+  danger: 'bg-red-50 text-red-700',
+  warn: 'bg-amber-50 text-amber-700',
+  teal: 'bg-brand-teal-tint text-brand-teal-dark',
+  blue: 'bg-sky-50 text-sky-700',
+  indigo: 'bg-[#f3f0ff] text-[#5e6ad2]',
 };
 
 export function Badge({ tone = 'neutral', className, ...props }: BadgeProps) {
   return (
     <span
       className={cn(
-        'inline-flex h-5 items-center rounded-full border px-2 text-[11px] font-medium tracking-normal',
+        'inline-flex h-[18px] items-center rounded px-1.5 text-[11px] font-medium tabular-nums leading-none',
         toneStyles[tone],
         className
       )}
       {...props}
     />
+  );
+}
+
+// StatusDot — Linear status pattern: colored dot + medium-weight text.
+// Use this for row/cell status, never a filled pill.
+interface StatusDotProps extends HTMLAttributes<HTMLSpanElement> {
+  tone?: 'neutral' | 'success' | 'danger' | 'warn' | 'brand' | 'indigo';
+  label: string;
+}
+
+const dotStyles: Record<NonNullable<StatusDotProps['tone']>, string> = {
+  neutral: 'bg-[#8a8f98]',
+  success: 'bg-emerald-500',
+  danger: 'bg-red-500',
+  warn: 'bg-amber-500',
+  brand: 'bg-brand-teal',
+  indigo: 'bg-[#5e6ad2]',
+};
+
+export function StatusDot({ tone = 'neutral', label, className, ...props }: StatusDotProps) {
+  return (
+    <span
+      className={cn('inline-flex items-center gap-1.5 text-[11.5px] font-medium text-[#3d4149]', className)}
+      {...props}
+    >
+      <span className={cn('h-1.5 w-1.5 rounded-full', dotStyles[tone])} />
+      {label}
+    </span>
   );
 }

--- a/apps/workshop/src/components/ui/button.tsx
+++ b/apps/workshop/src/components/ui/button.tsx
@@ -1,7 +1,10 @@
 import type { ButtonHTMLAttributes } from 'react';
 import { cn } from '@/lib/cn';
 
-type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger' | 'subtle';
+// Button — follows ui-design skill. Primary is Aiwah teal and should appear
+// at most once per screen. Prefer outline/ghost for everything else.
+
+type ButtonVariant = 'primary' | 'outline' | 'secondary' | 'ghost' | 'subtle' | 'danger';
 type ButtonSize = 'xs' | 'sm' | 'md';
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -11,25 +14,30 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 
 const variantStyles: Record<ButtonVariant, string> = {
   primary:
-    'border border-brand-teal bg-brand-teal text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.18)] hover:border-brand-teal-dark hover:bg-brand-teal-dark',
+    'bg-brand-teal text-white shadow-[inset_0_1px_0_0_rgba(255,255,255,0.12)] hover:bg-brand-teal-dark',
+  outline:
+    'border border-[#e6e8eb] bg-white text-[#3d4149] hover:bg-[#fafbfb] hover:border-[#d0d6e0]',
   secondary:
-    'border border-divider bg-[var(--app-bg-elevated)] text-[var(--app-fg)] hover:bg-[var(--app-input-bg)]',
-  ghost: 'border border-transparent bg-transparent text-[var(--app-fg)] hover:border-divider hover:bg-[var(--app-input-bg)]',
-  subtle: 'border border-divider bg-[var(--app-input-bg)] text-[var(--app-muted)] hover:text-[var(--app-fg)]',
-  danger: 'border border-red-600 bg-red-600 text-white hover:border-red-700 hover:bg-red-700',
+    'bg-[#f3f4f5] text-[#3d4149] hover:bg-[#e6e8eb]',
+  ghost:
+    'text-[#62666d] hover:bg-[#f3f4f5] hover:text-[#0f1011]',
+  subtle:
+    'bg-[#fafbfb] text-[#62666d] hover:bg-[#f3f4f5] hover:text-[#0f1011]',
+  danger:
+    'bg-[#dc2626] text-white hover:bg-[#b91c1c]',
 };
 
 const sizeStyles: Record<ButtonSize, string> = {
   xs: 'h-7 px-2.5 text-[12px]',
-  sm: 'h-8 px-3 text-[13px]',
+  sm: 'h-8 px-3 text-[12.5px]',
   md: 'h-9 px-3.5 text-[13px]',
 };
 
-export function Button({ variant = 'primary', size = 'sm', className, ...props }: ButtonProps) {
+export function Button({ variant = 'outline', size = 'sm', className, ...props }: ButtonProps) {
   return (
     <button
       className={cn(
-        'inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-[6px] font-medium leading-none transition-[background-color,border-color,color,box-shadow]',
+        'inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-md font-medium leading-none transition-colors',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-teal/45 focus-visible:ring-offset-1 focus-visible:ring-offset-[var(--app-bg)]',
         'disabled:cursor-not-allowed disabled:opacity-50',
         variantStyles[variant],

--- a/apps/workshop/src/lib/tokens.ts
+++ b/apps/workshop/src/lib/tokens.ts
@@ -1,9 +1,35 @@
+// Aiwah Workshop design tokens.
+// Follows the ui-design skill (Linear/Attio "tool look") with Aiwah teal as
+// the single brand accent. See skills/ui-design/SKILL.md.
+
 export const tokens = {
   colors: {
+    // Brand — one accent, used sparingly
     brandTeal: '#009E85',
     brandTealDark: '#007A66',
     brandTealTint: '#E0F7F3',
+
+    // Dark canvas (legacy — marketing only)
     canvasDark: '#0D1B2E',
+
+    // Surfaces (light)
+    page: '#fafbfb', // canvas — not pure white
+    surface: '#ffffff',
+    surfaceSubtle: '#f7f8f8', // hover, zebra
+    surfaceMuted: '#f3f4f5', // active tab, chip bg
+
+    // Borders — hairlines only
+    border: '#e6e8eb',
+    borderStrong: '#d0d6e0',
+    borderDivider: '#eff0f2',
+
+    // Text ramp — 4 steps, no more
+    textPrimary: '#0f1011',
+    textSecondary: '#3d4149',
+    textTertiary: '#62666d',
+    textMuted: '#8a8f98',
+
+    // Legacy aliases (kept for incremental migration)
     ink: '#0F172A',
     slate: '#475569',
     mist: '#94A3B8',
@@ -11,11 +37,11 @@ export const tokens = {
     divider: '#E2E8F0',
   },
   radius: {
-    xs: '4px',
-    sm: '6px',
-    md: '8px',
+    xs: '4px', // chips, badges
+    sm: '6px', // buttons, inputs
+    md: '8px', // cards, panels
     lg: '10px',
-    xl: '12px',
+    xl: '12px', // modals
     full: '9999px',
   },
   spacing: {
@@ -28,18 +54,34 @@ export const tokens = {
     4: '32px',
   },
   density: {
-    controlHeightXs: '28px',
-    controlHeightSm: '32px',
-    controlHeightMd: '36px',
+    // Control heights — dense by default
+    chip: '18px',
+    controlXs: '24px',
+    controlSm: '28px',
+    controlMd: '32px',
+    rowSm: '36px',
+    rowMd: '44px',
+    topbar: '44px',
     cellPaddingX: '12px',
     cellPaddingY: '10px',
   },
   typography: {
+    // size keys map to the ui-design ramp
+    label: '11px', // uppercase meta, tracking 0.04em
+    meta: '11px',
     caption: '12px',
-    body: '13px',
-    bodyLg: '14px',
-    titleSm: '22px',
-    titleMd: '28px',
-    titleLg: '34px',
+    body: '12.5px', // default cell text
+    bodyLg: '13px',
+    headingXs: '13px',
+    headingSm: '16px',
+    titleSm: '20px', // page H1 — not 30px
+    titleMd: '22px',
+    titleLg: '28px',
+  },
+  shadow: {
+    card: 'none',
+    popover:
+      '0 4px 12px -2px rgba(15,17,17,0.08), 0 0 0 1px rgba(15,17,17,0.05)',
+    buttonPrimary: 'inset 0 1px 0 0 rgba(255,255,255,0.12)',
   },
 } as const;


### PR DESCRIPTION
## Summary
- Codified a Linear/Attio-inspired \"tool look\" design system in `skills/ui-design/SKILL.md` (in the workspace) and applied it to Workshop primitives + dashboard
- Tokens, button, badge, and globals.css now follow hairline-border, dense-row, flat-chip conventions; Aiwah teal kept as the single brand accent
- Dashboard rewritten as a dense operational landing (breadcrumb header, stat row, hover-reveal quick-link list) — no gradient hero, no bold H1

## Changes
- `apps/workshop/src/lib/tokens.ts` — Linear light surfaces, hairline borders, 4-step text ramp, dense control heights
- `apps/workshop/src/components/ui/button.tsx` — add `outline`/`subtle` variants, default is `outline`, primary keeps Aiwah teal
- `apps/workshop/src/components/ui/badge.tsx` — flat 18px tinted chip + new `StatusDot` (dot+text status pattern)
- `apps/workshop/src/app/globals.css` — canvas `#fafbfb`, border `#e6e8eb`, no card shadow, body 12.5px with Inter `cv11`
- `apps/workshop/src/app/(app)/dashboard/page.tsx` — full Linear-style dashboard

## Test plan
- [ ] `pnpm dev` in `apps/workshop`, visit `/dashboard` — verify breadcrumb + stat row + quick-link list render cleanly
- [ ] Spot-check Button primary/outline/ghost render with new tokens
- [ ] Spot-check Badge tones + StatusDot
- [ ] Run `pnpm test` across api/shared (no logic changes expected to affect tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)